### PR TITLE
Suppression du error logging

### DIFF
--- a/account/server.php
+++ b/account/server.php
@@ -1,9 +1,5 @@
 <?php
 
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
-
 session_start();
 
 require_once dirname(__DIR__) . '/db.php';


### PR DESCRIPTION
Supression du message d'erreur "session_start(): Ignoring session_start() because a session is already active in (...)" sur la page /account/